### PR TITLE
Added support for Webpack 4

### DIFF
--- a/index.js
+++ b/index.js
@@ -14,7 +14,7 @@ UnusedPlugin.prototype.apply = function(compiler) {
     'emit',
     function(compilation, callback) {
       // Files used by Webpack during compilation
-      const usedModules = compilation.fileDependencies
+      const usedModules = Array.from(compilation.fileDependencies)
         .filter(file =>
           this.sourceDirectories.some(dir => file.indexOf(dir) !== -1)
         )


### PR DESCRIPTION
`compilation.fileDependencies` is now an Array-like as of Webpack 4. This change is backwards-compatible.

Closes #3