### PR TITLE
add webpack to peerDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,9 @@
     "chalk": "^2.1.0",
     "deglob": "^3.1.0"
   },
+  "peerDependencies": {
+    "webpack": "^3.6.0"
+  },
   "husky": {
     "hooks": {
       "pre-commit": "lint-staged"


### PR DESCRIPTION
Add `webpack` to peerDependencies since this is a webpack plugin :)

And the version of `webpack` is inspired by [example/package.json](https://github.com/MatthieuLemoine/unused-webpack-plugin/blob/57f6f9bf61c612b24404afd93984ff6a80d81dc2/examples/package.json#L13)