### PR TITLE
Show only directories with unused files

### DIFF
--- a/index.js
+++ b/index.js
@@ -61,6 +61,7 @@ function display(filesByDirectory) {
     chalk.red(`${allFiles.length} unused source files found.\n`),
   );
   filesByDirectory.forEach((files, index) => {
+    if (files.length === 0) return;
     const directory = this.sourceDirectories[index];
     const relative = this.root
       ? path.relative(this.root, directory)


### PR DESCRIPTION
before:

```
*** Unused Plugin ***
1 unused source files found.

● src

● other
    • other.css

*** Unused Plugin ***
```

after:

```
*** Unused Plugin ***
1 unused source files found.

● other
    • other.css

*** Unused Plugin ***
```