### PR TITLE
Use webpack logger API

### DIFF
--- a/index.js
+++ b/index.js
@@ -50,7 +50,7 @@ function continueOrFail(failOnUnused, compilation, allFiles) {
 function display(compilation, filesByDirectory) {
   const log = compilation.getLogger
     ? msg => compilation.getLogger('UnusedPlugin').warn(msg)
-    : msg => process.stdout.write(chalk.red(`UnusedPlugin: ${msg}\n`));
+    : msg => process.stderr.write(chalk.red(`UnusedPlugin: ${msg}\n`));
 
   const allFiles = filesByDirectory.reduce(
     (array, item) => array.concat(item),


### PR DESCRIPTION
The goal of this is to start using webpack logging API for plugins https://webpack.js.org/api/plugins/#logging (introduced with 4.37) to report status of UnusedWebpackPlugin instead of process.stdout.

Logging using stdout makes it hard for user to filter out plugin specific output or output in a different format (eg it breaks --json output making scripting harder). This keeps compat with < 4.37 by falling back on process.stderr which is slightly easier to filter out when using --json (`2>/dev/null`).

The output is less cute that what's currently in master in fallback mode (only using red, on stderr and I prefixed instead of header/footer to allow for easier `grep -v`).

This is the output in webpack 4.37+ (use of warn level):
```
LOG from UnusedPlugin
<w> 999 unused source files found.
<w> ● src
<w>     • ...
```

And here is the output in pre 4.37 (printed in red):

```
UnusedPlugin: 999 unused source files found.
UnusedPlugin: ● src
UnusedPlugin:     • ...
```