### PR TITLE
Add support to output result to file in markdown

### DIFF
--- a/README.md
+++ b/README.md
@@ -27,6 +27,8 @@ module.exports = {
       exclude: ['*.test.js'],
       // Root directory (optional)
       root: __dirname,
+      // Export file path (optional)
+      outputFilePath: path.resolve(__dirname, 'UNUSED_FILES.MD'),
     }),
   ],
 };
@@ -39,6 +41,7 @@ module.exports = {
 - `root` : root directory that will be use to display relative paths instead of absolute ones (see below)
 - `failOnUnused`: whether or not the build should fail if unused files are found (defaults to `false`)
 - `useGitIgnore`: whether or not to respect `.gitignore` file (defaults to `true`)
+- `outputFilePath`: Full path to the file where you want the results be printed to.
 
 With root
 

--- a/index.js
+++ b/index.js
@@ -77,22 +77,17 @@ ${allFiles.length} unused source files found.
     process.stdout.write(chalk.blue(`\n● ${relative}\n`));
     outputString += `\n### ${relative}\n`;
 
-    files.forEach(file => {
+    files.forEach((file) => {
       process.stdout.write(
         chalk.yellow(`    • ${path.relative(directory, file)}\n`),
-      )
+      );
       outputString += `  - ${path.relative(directory, file)}\n`;
     });
   });
   process.stdout.write(chalk.green('\n*** Unused Plugin ***\n\n'));
 
   if (this.outputFilePath) {
-    fs.writeFile(
-      this.outputFilePath,
-      outputString,
-      'utf8',
-      err => console.warn(err)
-    );
+    fs.writeFile(this.outputFilePath, outputString, 'utf8');
   }
 
   return allFiles;


### PR DESCRIPTION
This PR adds an additional `outputFilePath` field to config.
If it's specified you'll get the results output in markdown format to that given file path.

This should help address #8
