### PR TITLE
Output to a file

### DIFF
--- a/README.md
+++ b/README.md
@@ -39,6 +39,7 @@ module.exports = {
 - `root` : root directory that will be use to display relative paths instead of absolute ones (see below)
 - `failOnUnused`: whether or not the build should fail if unused files are found (defaults to `false`)
 - `useGitIgnore`: whether or not to respect `.gitignore` file (defaults to `true`)
+- `outputFile`: if specified, unused files will be output to this file, instead of the console
 
 With root
 


### PR DESCRIPTION
This PR adds in the ability to output to a file, as well as just to the console. (should resolve https://github.com/MatthieuLemoine/unused-webpack-plugin/issues/8)

For example, with a config of:

```javascript
new UnusedWebpackPlugin({
  // Source directories
  directories: [
    path.join(__dirname, 'awesome-module'),
    path.join(__dirname, 'simple-module'),
  ],
  // Exclude patterns
  exclude: ['**/*.test.js'],
  // Root directory (optional)
  root: __dirname,
  failOnUnused: false,
})
```

you would get this logged to the console:

```
*** Unused Plugin ***
4 unused source files found.

● awesome-module
    • actions/destroy.js
    • config/index.js

● simple-module
    • routes/index.js
    • utils/date.js

*** Unused Plugin ***
```

but with the following config, instead:

```javascript
new UnusedWebpackPlugin({
  // Source directories
  directories: [
    path.join(__dirname, 'awesome-module'),
    path.join(__dirname, 'simple-module'),
  ],
  // Exclude patterns
  exclude: ['**/*.test.js'],
  // Root directory (optional)
  root: __dirname,
  failOnUnused: false,
  outputFile: 'unused_manifest',
})
```

then you would get nothing printing to the console, but `cat dist/unused_manifest` would return:

```
/some/user/path/unused-webpack-plugin/examples/awesome-module/actions/destroy.js                                                                                        
/some/user/path/unused-webpack-plugin/examples/awesome-module/config/index.js
/some/user/path/unused-webpack-plugin/examples/simple-module/routes/index.js
/some/user/path/unused-webpack-plugin/examples/simple-module/utils/date.js
```